### PR TITLE
Add frontend base game logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ tokio = { version = "1.2", features = ["time", "macros", "rt-multi-thread"] }
 tokio-tungstenite = "0.14"
 tungstenite = "0.13"
 url = "2.2"
+bevy = "0.4.0"
+rand = "0.8.3"
 
 [[bin]]
 name = "server"
@@ -23,8 +25,14 @@ path = "src/server.rs"
 name = "client"
 path = "src/client.rs"
 
+[[bin]]
+name = "front"
+path = "src/front.rs"
+
 [package.metadata.commands]
-'run:server'   = "cargo run --bin server"
-'run:client'   = "cargo run --bin client"
-'build:server' = "cargo build --bin server --release; ls target/release/server"
-'build:client' = "cargo build --bin client --release; ls target/release/client"
+'run:server'    = "cargo run --bin server"
+'run:client'    = "cargo run --bin client"
+'run:front'     = "cargo +nightly run --bin front --features bevy/dynamic"
+'build:server'  = "cargo build --bin server --release; ls target/release/server"
+'build:client'  = "cargo build --bin client --release; ls target/release/client"
+'build:front'   = "cargo +nightly build --bin front --release; ls target/release/front"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ tokio = { version = "1.2", features = ["time", "macros", "rt-multi-thread"] }
 tokio-tungstenite = "0.14"
 tungstenite = "0.13"
 url = "2.2"
-bevy = "0.4.0"
+bevy = "0.5.0"
 rand = "0.8.3"
 
 [[bin]]

--- a/readme.md
+++ b/readme.md
@@ -6,10 +6,12 @@ Configure project: run `.configure/run`
 This will install `cargo-cmd`, add a git hook for validation and add the `.env` file to the root of your project  
 Now you can configure the `.env` file as you want
 
-You can use `cargo cmd (build|run):(client|server)` if you have installed `cargo-cmd`  
+You can use `cargo cmd (build|run):(client|server|front)` if you have installed `cargo-cmd`  
 Like: `cargo cmd run:client`
 
 But if you prefer, you can still run the standard cargo command
+
+> NB: you need to [install dependencies for bevy](https://bevyengine.org/learn/book/getting-started/setup/)
 
 ## Before each push:
 

--- a/src/front.rs
+++ b/src/front.rs
@@ -1,16 +1,10 @@
-use bevy::{
-    prelude::*,
-    render::pass::ClearColor,
-    sprite::collide_aabb::{collide, Collision},
-};
-use std::num;
-use std::thread::spawn;
+use bevy::{prelude::*, render::pass::ClearColor};
 
 const ARENA_WIDTH: i32 = 10;
 const ARENA_HEIGHT: i32 = 10;
 
 struct Material {
-    mat : Handle<ColorMaterial>,
+    mat: Handle<ColorMaterial>,
 }
 
 #[derive(Default, Copy, Clone, PartialEq)]
@@ -60,16 +54,21 @@ fn position_translation(windows: Res<Windows>, mut q: Query<(&Position, &mut Tra
 }
 
 struct Ball;
-fn spawn_ball(commands: &mut Commands, material: Res<Material>) {
+fn spawn_ball(mut commands: Commands, material: Res<Material>) {
     commands
-        .spawn(SpriteBundle {
+        .spawn_bundle(SpriteBundle {
             material: material.mat.clone(),
             sprite: Sprite::new(Vec2::new(10.0, 10.0)),
             ..Default::default()
         })
-        .with(Ball)
-        .with(Position {x: 5., y: 5., vx: 0.08, vy: 0.03})
-        .with(Size::square(0.8));
+        .insert(Ball)
+        .insert(Position {
+            x: 5.,
+            y: 5.,
+            vx: 0.08,
+            vy: 0.03,
+        })
+        .insert(Size::square(0.8));
 }
 
 fn ball_movement(mut position: Query<&mut Position, With<Ball>>) {
@@ -80,29 +79,26 @@ fn ball_movement(mut position: Query<&mut Position, With<Ball>>) {
         if pos.y >= ARENA_HEIGHT as f32 - 1.0 || pos.y <= 0. {
             pos.vy = -pos.vy;
         }
-        
         pos.x += pos.vx;
         pos.y += pos.vy;
     }
 }
 
-fn setup(commands: &mut Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
-    commands
-        .spawn(Camera2dBundle::default())
-        .insert_resource(Material {
-            mat: materials.add(Color::rgb(0.7, 0.7, 0.7).into()),
-        });
+fn setup(mut commands: Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
+    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+    commands.insert_resource(Material {
+        mat: materials.add(Color::rgb(0.7, 0.7, 0.7).into()),
+    });
 }
-
 
 fn main() {
     App::build()
-        .add_resource(ClearColor(Color::rgb(0.04, 0.04, 0.04)))
-        .add_resource(WindowDescriptor {
-            title: "Pong!".to_string(), 
-            width: 500.0,                
-            height: 500.0,                
-            ..Default::default()        
+        .insert_resource(ClearColor(Color::rgb(0.04, 0.04, 0.04)))
+        .insert_resource(WindowDescriptor {
+            title: "Pong!".to_string(),
+            width: 500.0,
+            height: 500.0,
+            ..Default::default()
         })
         .add_startup_system(setup.system())
         .add_startup_stage("game_setup", SystemStage::single(spawn_ball.system()))

--- a/src/front.rs
+++ b/src/front.rs
@@ -1,0 +1,114 @@
+use bevy::{
+    prelude::*,
+    render::pass::ClearColor,
+    sprite::collide_aabb::{collide, Collision},
+};
+use std::num;
+use std::thread::spawn;
+
+const ARENA_WIDTH: i32 = 10;
+const ARENA_HEIGHT: i32 = 10;
+
+struct Material {
+    mat : Handle<ColorMaterial>,
+}
+
+#[derive(Default, Copy, Clone, PartialEq)]
+struct Position {
+    x: f32,
+    y: f32,
+    vx: f32,
+    vy: f32,
+}
+
+struct Size {
+    width: f32,
+    height: f32,
+}
+impl Size {
+    pub fn square(x: f32) -> Self {
+        Self {
+            width: x,
+            height: x,
+        }
+    }
+}
+
+fn size_scaling(windows: Res<Windows>, mut q: Query<(&Size, &mut Sprite)>) {
+    let window = windows.get_primary().unwrap();
+    for (sprite_size, mut sprite) in q.iter_mut() {
+        sprite.size = Vec2::new(
+            sprite_size.width / ARENA_WIDTH as f32 * window.width(),
+            sprite_size.height / ARENA_HEIGHT as f32 * window.height(),
+        );
+    }
+}
+
+fn position_translation(windows: Res<Windows>, mut q: Query<(&Position, &mut Transform)>) {
+    fn convert(pos: f32, bound_window: f32, bound_game: f32) -> f32 {
+        let tile_size = bound_window / bound_game;
+        pos / bound_game * bound_window - (bound_window / 2.) + (tile_size / 2.)
+    }
+    let window = windows.get_primary().unwrap();
+    for (pos, mut transform) in q.iter_mut() {
+        transform.translation = Vec3::new(
+            convert(pos.x, window.width(), ARENA_WIDTH as f32),
+            convert(pos.y, window.height(), ARENA_HEIGHT as f32),
+            0.0,
+        );
+    }
+}
+
+struct Ball;
+fn spawn_ball(commands: &mut Commands, material: Res<Material>) {
+    commands
+        .spawn(SpriteBundle {
+            material: material.mat.clone(),
+            sprite: Sprite::new(Vec2::new(10.0, 10.0)),
+            ..Default::default()
+        })
+        .with(Ball)
+        .with(Position {x: 5., y: 5., vx: 0.08, vy: 0.03})
+        .with(Size::square(0.8));
+}
+
+fn ball_movement(mut position: Query<&mut Position, With<Ball>>) {
+    for mut pos in position.iter_mut() {
+        if pos.x >= ARENA_WIDTH as f32 - 1.0 || pos.x <= 0. {
+            pos.vx = -pos.vx;
+        }
+        if pos.y >= ARENA_HEIGHT as f32 - 1.0 || pos.y <= 0. {
+            pos.vy = -pos.vy;
+        }
+        
+        pos.x += pos.vx;
+        pos.y += pos.vy;
+    }
+}
+
+fn setup(commands: &mut Commands, mut materials: ResMut<Assets<ColorMaterial>>) {
+    commands
+        .spawn(Camera2dBundle::default())
+        .insert_resource(Material {
+            mat: materials.add(Color::rgb(0.7, 0.7, 0.7).into()),
+        });
+}
+
+
+fn main() {
+    App::build()
+        .add_resource(ClearColor(Color::rgb(0.04, 0.04, 0.04)))
+        .add_resource(WindowDescriptor {
+            title: "Pong!".to_string(), 
+            width: 500.0,                
+            height: 500.0,                
+            ..Default::default()        
+        })
+        .add_startup_system(setup.system())
+        .add_startup_stage("game_setup", SystemStage::single(spawn_ball.system()))
+        .add_system(position_translation.system())
+        .add_system(size_scaling.system())
+        .add_system(ball_movement.system())
+        .add_plugins(DefaultPlugins)
+        .run();
+}


### PR DESCRIPTION
This adds the very first iteration of the Front version of the game

- This adds a simple ball logic until it will be directed by the game server **must be deleted**
- Display the ball for the given screen size

**TODO**
- tickrate
- env vars for tickrate and screen size
- Investigate and implement networking

**Additional changes**
- Run/build automation